### PR TITLE
Style improvement: wrap Devise views in container layout

### DIFF
--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,20 +1,22 @@
-<h2 class="text-2xl font-semibold mb-4">Resend confirmation instructions</h2>
+<%= render "shared/devise_container" do %>
+  <h2 class="text-2xl font-semibold mb-4">Resend confirmation instructions</h2>
 
-<%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post, class: "space-y-4" }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+  <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post, class: "space-y-4" }) do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="flex flex-col">
-    <%= f.label :email, class: "text-sm font-medium text-gray-700" %>
-    <%= f.email_field :email, autofocus: true, autocomplete: "email",
-      value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email),
-      class: "mt-1 p-2 border rounded-md" %>
-  </div>
+    <div class="flex flex-col">
+      <%= f.label :email, class: "text-sm font-medium text-gray-700" %>
+      <%= f.email_field :email, autofocus: true, autocomplete: "email",
+        value: (resource.pending_reconfirmation? ? resource.unconfirmed_email : resource.email),
+        class: "mt-1 p-2 border rounded-md" %>
+    </div>
 
-  <div>
-    <%= f.submit "Resend confirmation instructions", class: "bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700" %>
+    <div>
+      <%= f.submit "Resend confirmation instructions", class: "bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700" %>
+    </div>
+  <% end %>
+
+  <div class="mt-4 text-sm text-gray-600">
+    <%= render "devise/shared/links" %>
   </div>
 <% end %>
-
-<div class="mt-4 text-sm text-gray-600">
-  <%= render "devise/shared/links" %>
-</div>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,28 +1,29 @@
-<h2 class="text-2xl font-semibold mb-4">Change your password</h2>
+<%= render "shared/devise_container" do %>
+  <h2 class="text-2xl font-semibold mb-4">Change your password</h2>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put, class: "space-y-4" }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
-  <%= f.hidden_field :reset_password_token %>
+  <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put, class: "space-y-4" }) do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
+    <%= f.hidden_field :reset_password_token %>
 
-  <div class="flex flex-col">
-    <%= f.label :password, "New password", class: "text-sm font-medium text-gray-700" %>
-    <% if @minimum_password_length %>
-      <small class="text-xs text-gray-500 mb-1">(<%= @minimum_password_length %> characters minimum)</small>
-    <% end %>
-    <%= f.password_field :password, autofocus: true, autocomplete: "new-password", class: "p-2 border rounded-md" %>
-  </div>
+    <div class="flex flex-col">
+      <%= f.label :password, "New password", class: "text-sm font-medium text-gray-700" %>
+      <% if @minimum_password_length %>
+        <small class="text-xs text-gray-500 mb-1">(<%= @minimum_password_length %> characters minimum)</small>
+      <% end %>
+      <%= f.password_field :password, autofocus: true, autocomplete: "new-password", class: "p-2 border rounded-md" %>
+    </div>
 
-  <div class="flex flex-col">
-    <%= f.label :password_confirmation, "Confirm new password", class: "text-sm font-medium text-gray-700" %>
-    <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "p-2 border rounded-md" %>
-  </div>
+    <div class="flex flex-col">
+      <%= f.label :password_confirmation, "Confirm new password", class: "text-sm font-medium text-gray-700" %>
+      <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "p-2 border rounded-md" %>
+    </div>
 
-  <div>
-    <%= f.submit "Change my password", class: "bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700" %>
+    <div>
+      <%= f.submit "Change my password", class: "bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700" %>
+    </div>
+  <% end %>
+
+  <div class="mt-4 text-sm text-gray-600">
+    <%= render "devise/shared/links" %>
   </div>
 <% end %>
-
-<div class="mt-4 text-sm text-gray-600">
-  <%= render "devise/shared/links" %>
-</div>
-

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,18 +1,20 @@
-<h2 class="text-2xl font-semibold mb-4">Forgot your password?</h2>
+<%= render "shared/devise_container" do %>
+  <h2 class="text-2xl font-semibold mb-4">Forgot your password?</h2>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, class: "space-y-4" }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+  <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post, class: "space-y-4" }) do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="flex flex-col">
-    <%= f.label :email, class: "text-sm font-medium text-gray-700" %>
-    <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "mt-1 p-2 border rounded-md" %>
-  </div>
+    <div class="flex flex-col">
+      <%= f.label :email, class: "text-sm font-medium text-gray-700" %>
+      <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "mt-1 p-2 border rounded-md" %>
+    </div>
 
-  <div>
-    <%= f.submit "Send me reset password instructions", class: "bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700" %>
+    <div>
+      <%= f.submit "Send me reset password instructions", class: "bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700" %>
+    </div>
+  <% end %>
+
+  <div class="mt-4 text-sm text-gray-600">
+    <%= render "devise/shared/links" %>
   </div>
 <% end %>
-
-<div class="mt-4 text-sm text-gray-600">
-  <%= render "devise/shared/links" %>
-</div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,47 +1,52 @@
-<h2 class="text-2xl font-semibold mb-4">Edit <%= resource_name.to_s.humanize %></h2>
+<%= render "shared/devise_container" do %>
+  <h2 class="text-2xl font-semibold mb-4">Edit <%= resource_name.to_s.humanize %></h2>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, class: "space-y-4" }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+  <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put, class: "space-y-4" }) do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="flex flex-col">
-    <%= f.label :email, class: "text-sm font-medium text-gray-700" %>
-    <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "mt-1 p-2 border rounded-md" %>
-  </div>
+    <div class="flex flex-col">
+      <%= f.label :email, class: "text-sm font-medium text-gray-700" %>
+      <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "mt-1 p-2 border rounded-md" %>
+    </div>
 
-  <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div class="text-sm text-yellow-600">
-      Currently waiting confirmation for: <%= resource.unconfirmed_email %>
+    <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
+      <div class="text-sm text-yellow-600">
+        Currently waiting confirmation for: <%= resource.unconfirmed_email %>
+      </div>
+    <% end %>
+
+    <div class="flex flex-col">
+      <%= f.label :password, class: "text-sm font-medium text-gray-700" %>
+      <small class="text-xs text-gray-500">(leave blank if you don't want to change it)</small>
+      <%= f.password_field :password, autocomplete: "new-password", class: "mt-1 p-2 border rounded-md" %>
+      <% if @minimum_password_length %>
+        <small class="text-xs text-gray-500 mt-1">(<%= @minimum_password_length %> characters minimum)</small>
+      <% end %>
+    </div>
+
+    <div class="flex flex-col">
+      <%= f.label :password_confirmation, class: "text-sm font-medium text-gray-700" %>
+      <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "mt-1 p-2 border rounded-md" %>
+    </div>
+
+    <div class="flex flex-col">
+      <%= f.label :current_password, class: "text-sm font-medium text-gray-700" %>
+      <small class="text-xs text-gray-500">(we need your current password to confirm your changes)</small>
+      <%= f.password_field :current_password, autocomplete: "current-password", class: "mt-1 p-2 border rounded-md" %>
+    </div>
+
+    <div>
+      <%= f.submit "Update", class: "bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700" %>
     </div>
   <% end %>
 
-  <div class="flex flex-col">
-    <%= f.label :password, class: "text-sm font-medium text-gray-700" %>
-    <small class="text-xs text-gray-500">(leave blank if you don't want to change it)</small>
-    <%= f.password_field :password, autocomplete: "new-password", class: "mt-1 p-2 border rounded-md" %>
-    <% if @minimum_password_length %>
-      <small class="text-xs text-gray-500 mt-1">(<%= @minimum_password_length %> characters minimum)</small>
-    <% end %>
+  <div class="mt-4 mb-4">
+    <p class="text-sm text-gray-600 mb-2">Unhappy with your account?</p>
+    <%= button_to "Cancel my account", registration_path(resource_name),
+          method: :delete,
+          data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" },
+          class: "bg-red-600 text-white px-4 py-2 rounded hover:bg-red-700" %>
   </div>
 
-  <div class="flex flex-col">
-    <%= f.label :password_confirmation, class: "text-sm font-medium text-gray-700" %>
-    <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "mt-1 p-2 border rounded-md" %>
-  </div>
-
-  <div class="flex flex-col">
-    <%= f.label :current_password, class: "text-sm font-medium text-gray-700" %>
-    <small class="text-xs text-gray-500">(we need your current password to confirm your changes)</small>
-    <%= f.password_field :current_password, autocomplete: "current-password", class: "mt-1 p-2 border rounded-md" %>
-  </div>
-
-  <div>
-    <%= f.submit "Update", class: "bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700" %>
-  </div>
+  <%= link_to "Back", root_path, class: "text-sm text-blue-600 hover:underline" %>
 <% end %>
-
-<h3 class="text-lg font-semibold mt-8">Cancel my account</h3>
-<div class="mb-4">
-  <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete, class: "text-red-600 hover:underline" %>
-</div>
-
-<%= link_to "Back", root_path, class: "text-sm text-blue-600 hover:underline" %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,31 +1,33 @@
-<h2 class="text-2xl font-semibold mb-4">Sign up</h2>
+<%= render "shared/devise_container" do %>
+  <h2 class="text-2xl font-semibold mb-4">Sign up</h2>
 
-<%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { class: "space-y-4" }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+  <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { class: "space-y-4" }) do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="flex flex-col">
-    <%= f.label :email, class: "text-sm font-medium text-gray-700" %>
-    <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "mt-1 p-2 border rounded-md" %>
-  </div>
+    <div class="flex flex-col">
+      <%= f.label :email, class: "text-sm font-medium text-gray-700" %>
+      <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "mt-1 p-2 border rounded-md" %>
+    </div>
 
-  <div class="flex flex-col">
-    <%= f.label :password, class: "text-sm font-medium text-gray-700" %>
-    <% if @minimum_password_length %>
-      <small class="text-xs text-gray-500 mb-1">(<%= @minimum_password_length %> characters minimum)</small>
-    <% end %>
-    <%= f.password_field :password, autocomplete: "new-password", class: "p-2 border rounded-md" %>
-  </div>
+    <div class="flex flex-col">
+      <%= f.label :password, class: "text-sm font-medium text-gray-700" %>
+      <% if @minimum_password_length %>
+        <small class="text-xs text-gray-500 mb-1">(<%= @minimum_password_length %> characters minimum)</small>
+      <% end %>
+      <%= f.password_field :password, autocomplete: "new-password", class: "p-2 border rounded-md" %>
+    </div>
 
-  <div class="flex flex-col">
-    <%= f.label :password_confirmation, class: "text-sm font-medium text-gray-700" %>
-    <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "mt-1 p-2 border rounded-md" %>
-  </div>
+    <div class="flex flex-col">
+      <%= f.label :password_confirmation, class: "text-sm font-medium text-gray-700" %>
+      <%= f.password_field :password_confirmation, autocomplete: "new-password", class: "mt-1 p-2 border rounded-md" %>
+    </div>
 
-  <div>
-    <%= f.submit "Sign up", class: "bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700" %>
+    <div>
+      <%= f.submit "Sign up", class: "bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700" %>
+    </div>
+  <% end %>
+
+  <div class="mt-4 text-sm text-gray-600">
+    <%= render "devise/shared/links" %>
   </div>
 <% end %>
-
-<div class="mt-4 text-sm text-gray-600">
-  <%= render "devise/shared/links" %>
-</div>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,26 +1,28 @@
-<h2 class="text-2xl font-semibold mb-4">Log in</h2>
+<%= render "shared/devise_container" do %>
+  <h2 class="text-2xl font-semibold mb-4">Log in</h2>
 
-<%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: "space-y-4" }) do |f| %>
-  <%= render "devise/shared/error_messages", resource: resource %>
+  <%= form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: "space-y-4" }) do |f| %>
+    <%= render "devise/shared/error_messages", resource: resource %>
 
-  <div class="flex flex-col">
-    <%= f.label :email, class: "text-sm font-medium text-gray-700" %>
-    <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "mt-1 p-2 border rounded-md" %>
-  </div>
+    <div class="flex flex-col">
+      <%= f.label :email, class: "text-sm font-medium text-gray-700" %>
+      <%= f.email_field :email, autofocus: true, autocomplete: "email", class: "mt-1 p-2 border rounded-md" %>
+    </div>
 
-  <div class="flex flex-col">
-    <%= f.label :password, class: "text-sm font-medium text-gray-700" %>
-    <%= f.password_field :password, autocomplete: "current-password", class: "mt-1 p-2 border rounded-md" %>
-  </div>
+    <div class="flex flex-col">
+      <%= f.label :password, class: "text-sm font-medium text-gray-700" %>
+      <%= f.password_field :password, autocomplete: "current-password", class: "mt-1 p-2 border rounded-md" %>
+    </div>
 
-  <% if devise_mapping.rememberable? %>
-    <div class="flex items-center space-x-2">
-      <%= f.check_box :remember_me %>
-      <%= f.label :remember_me, class: "text-sm text-gray-700" %>
+    <% if devise_mapping.rememberable? %>
+      <div class="flex items-center space-x-2">
+        <%= f.check_box :remember_me %>
+        <%= f.label :remember_me, class: "text-sm text-gray-700" %>
+      </div>
+    <% end %>
+
+    <div>
+      <%= f.submit "Log in", class: "bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700" %>
     </div>
   <% end %>
-
-  <div>
-    <%= f.submit "Log in", class: "bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700" %>
-  </div>
 <% end %>

--- a/app/views/shared/_devise_container.html.erb
+++ b/app/views/shared/_devise_container.html.erb
@@ -1,0 +1,3 @@
+<div class="max-w-md mx-auto bg-white shadow-md p-6 rounded-md">
+  <%= yield %>
+</div>


### PR DESCRIPTION
This PR improves the visual layout of authentication-related pages by wrapping Devise views (login, sign-up, password, etc.) in a responsive, centered container using Tailwind CSS.

What was done:
    ✅ Created a shared partial to apply consistent styling (_devise_container.html.erb)
    ✅ Applied this wrapper to all major Devise views for uniform spacing and width
    ✅ Minor UI/UX tweaks to remove redundant headings and improve alignment