### PR TITLE
Feat(admin): implement admin panel with user management and pet listing moderation

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class Admin::BaseController < ApplicationController
+  before_action :authenticate_user!
+  before_action :require_admin
+
+  private
+
+  def require_admin
+    unless current_user&.admin?
+      redirect_to root_path, alert: "You are not authorized to access admin panel."
+    end
+  end
+end

--- a/app/controllers/admin/dashboard_controller.rb
+++ b/app/controllers/admin/dashboard_controller.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class Admin::DashboardController < Admin::BaseController
+  def index; end
+end

--- a/app/controllers/admin/pets_controller.rb
+++ b/app/controllers/admin/pets_controller.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class Admin::PetsController < Admin::BaseController
+  def index
+    @pets = Pet.includes(:user).order(created_at: :desc)
+  end
+
+  def toggle_status
+    @pet = Pet.find(params[:id])
+    if @pet.available?
+      @pet.adopted!
+    else
+      @pet.available!
+    end
+
+    redirect_to admin_pets_path, notice: "Toggled status for #{@pet.name}."
+  end
+end

--- a/app/controllers/admin/pets_controller.rb
+++ b/app/controllers/admin/pets_controller.rb
@@ -5,14 +5,9 @@ class Admin::PetsController < Admin::BaseController
     @pets = Pet.includes(:user).order(created_at: :desc)
   end
 
-  def toggle_status
+  def toggle_visibility
     @pet = Pet.find(params[:id])
-    if @pet.available?
-      @pet.adopted!
-    else
-      @pet.available!
-    end
-
-    redirect_to admin_pets_path, notice: "Toggled status for #{@pet.name}."
+    @pet.update(visible: !@pet.visible)
+    redirect_to admin_pets_path, notice: "#{@pet.name} is now #{ @pet.visible? ? 'visible' : 'hidden' }."
   end
 end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Admin::UsersController < Admin::BaseController
+  def index
+    @users = User.order(created_at: :desc)
+  end
+end

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -2,6 +2,21 @@
 
 class Admin::UsersController < Admin::BaseController
   def index
-    @users = User.order(created_at: :desc)
+    @users = User.all
+    @users = @users.where(role: params[:role]) if params[:role].present?
+    @users = @users.where(active: params[:active]) if params[:active].present?
+    @users = @users.order(created_at: :desc)
+  end
+
+  def toggle_admin
+    user = User.find(params[:id])
+    user.update(role: user.admin? ? :user : :admin)
+    redirect_to admin_users_path, notice: "Updated #{user.email}'s role."
+  end
+
+  def toggle_active
+    user = User.find(params[:id])
+    user.update(active: !user.active)
+    redirect_to admin_users_path, notice: "Toggled active status for #{user.email}."
   end
 end

--- a/app/helpers/admin/dashboard_helper.rb
+++ b/app/helpers/admin/dashboard_helper.rb
@@ -1,0 +1,2 @@
+module Admin::DashboardHelper
+end

--- a/app/helpers/admin/pets_helper.rb
+++ b/app/helpers/admin/pets_helper.rb
@@ -1,0 +1,2 @@
+module Admin::PetsHelper
+end

--- a/app/helpers/admin/users_helper.rb
+++ b/app/helpers/admin/users_helper.rb
@@ -1,0 +1,2 @@
+module Admin::UsersHelper
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,4 +9,12 @@ class User < ApplicationRecord
   has_many :notifications, dependent: :destroy
 
   scope :active, -> { where(active: true) }
+
+  def active_for_authentication?
+    super && active?
+  end
+  
+  def inactive_message
+    active? ? super : :inactive
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,6 @@ class User < ApplicationRecord
   has_many :adoption_requests, dependent: :destroy
   has_many :pets, dependent: :destroy
   has_many :notifications, dependent: :destroy
+
+  scope :active, -> { where(active: true) }
 end

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -2,7 +2,11 @@
   <h1 class="text-2xl font-bold mb-6">Admin Panel</h1>
 
   <ul class="space-y-3">
-    <li><%= link_to "Manage Users", "#" %></li>
-    <li><%= link_to "Moderate Pet Listings", "#" %></li>
+    <li>
+      <%= link_to "Manage Users", admin_users_path, class: "text-blue-600 hover:underline" %>
+    </li>
+    <li>
+      <%= link_to "Moderate Pet Listings", admin_pets_path, class: "text-blue-600 hover:underline" %>
+    </li>
   </ul>
 </div>

--- a/app/views/admin/dashboard/index.html.erb
+++ b/app/views/admin/dashboard/index.html.erb
@@ -1,0 +1,8 @@
+<div class="max-w-4xl mx-auto p-8">
+  <h1 class="text-2xl font-bold mb-6">Admin Panel</h1>
+
+  <ul class="space-y-3">
+    <li><%= link_to "Manage Users", "#" %></li>
+    <li><%= link_to "Moderate Pet Listings", "#" %></li>
+  </ul>
+</div>

--- a/app/views/admin/pets/index.html.erb
+++ b/app/views/admin/pets/index.html.erb
@@ -9,20 +9,35 @@
         <th class="p-2 border">Size</th>
         <th class="p-2 border">Status</th>
         <th class="p-2 border">Owner</th>
+        <th class="p-2 border">Visibility</th>
         <th class="p-2 border">Actions</th>
       </tr>
     </thead>
     <tbody>
       <% @pets.each do |pet| %>
-        <tr>
+        <tr class="<%= pet.visible? ? '' : 'bg-gray-100 text-gray-500' %>">
           <td class="p-2 border font-semibold"><%= pet.name %></td>
           <td class="p-2 border"><%= pet.species.titleize %></td>
           <td class="p-2 border"><%= pet.size %></td>
           <td class="p-2 border capitalize"><%= pet.status %></td>
           <td class="p-2 border text-sm"><%= pet.user.email %></td>
           <td class="p-2 border">
-            <%= button_to "Toggle Status", toggle_status_admin_pet_path(pet), method: :patch,
-                  class: "text-sm text-blue-600 hover:underline" %>
+            <% if pet.visible? %>
+              <span class="text-green-600 font-semibold">Visible</span>
+            <% else %>
+              <span class="text-red-600 font-semibold">Hidden</span>
+            <% end %>
+          </td>
+          <td class="p-2 border">
+            <%= form_with url: toggle_visibility_admin_pet_path(pet), method: :patch, local: true do %>
+              <button type="submit" aria-label="Toggle visibility" class="relative inline-flex items-center h-6 w-11 rounded-full transition-colors focus:outline-none
+                <%= pet.visible? ? 'bg-green-500' : 'bg-gray-300' %>">
+                <span class="sr-only">Toggle Visibility</span>
+                <span class="inline-block h-4 w-4 transform bg-white rounded-full transition-transform duration-200 ease-in-out
+                  <%= pet.visible? ? 'translate-x-6' : 'translate-x-1' %>">
+                </span>
+              </button>
+            <% end %>
           </td>
         </tr>
       <% end %>

--- a/app/views/admin/pets/index.html.erb
+++ b/app/views/admin/pets/index.html.erb
@@ -1,0 +1,31 @@
+<div class="max-w-6xl mx-auto p-6">
+  <h1 class="text-2xl font-bold mb-6">Pet Listing Moderation</h1>
+
+  <table class="w-full table-auto border-collapse">
+    <thead>
+      <tr class="bg-gray-100 text-left">
+        <th class="p-2 border">Name</th>
+        <th class="p-2 border">Species</th>
+        <th class="p-2 border">Size</th>
+        <th class="p-2 border">Status</th>
+        <th class="p-2 border">Owner</th>
+        <th class="p-2 border">Actions</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @pets.each do |pet| %>
+        <tr>
+          <td class="p-2 border font-semibold"><%= pet.name %></td>
+          <td class="p-2 border"><%= pet.species.titleize %></td>
+          <td class="p-2 border"><%= pet.size %></td>
+          <td class="p-2 border capitalize"><%= pet.status %></td>
+          <td class="p-2 border text-sm"><%= pet.user.email %></td>
+          <td class="p-2 border">
+            <%= button_to "Toggle Status", toggle_status_admin_pet_path(pet), method: :patch,
+                  class: "text-sm text-blue-600 hover:underline" %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,0 +1,24 @@
+<div class="max-w-5xl mx-auto p-6">
+  <h1 class="text-2xl font-bold mb-6">User Management</h1>
+
+  <table class="w-full table-auto border-collapse">
+    <thead>
+      <tr class="bg-gray-100 text-left">
+        <th class="p-2 border">ID</th>
+        <th class="p-2 border">Email</th>
+        <th class="p-2 border">Role</th>
+        <th class="p-2 border">Created At</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @users.each do |user| %>
+        <tr>
+          <td class="p-2 border"><%= user.id %></td>
+          <td class="p-2 border"><%= user.email %></td>
+          <td class="p-2 border capitalize"><%= user.role %></td>
+          <td class="p-2 border text-sm text-gray-600"><%= user.created_at.strftime("%Y-%m-%d %H:%M") %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -28,7 +28,8 @@
         <th class="p-2 border">Email</th>
         <th class="p-2 border">Role</th>
         <th class="p-2 border">Created At</th>
-        <th class="p-2 border">Actions</th>
+        <th class="p-2 border">Admin</th>
+        <th class="p-2 border">Active</th>
       </tr>
     </thead>
     <tbody>
@@ -38,9 +39,31 @@
           <td class="p-2 border"><%= user.email %></td>
           <td class="p-2 border capitalize"><%= user.role %></td>
           <td class="p-2 border text-sm text-gray-600"><%= user.created_at.strftime("%Y-%m-%d %H:%M") %></td>
-          <td class="p-2 border space-x-2">
-            <%= button_to "Toggle Admin", toggle_admin_admin_user_path(user), method: :patch, class: "text-xs text-blue-600 hover:underline" %>
-            <%= button_to (user.active? ? "Deactivate" : "Reactivate"), toggle_active_admin_user_path(user), method: :patch, class: "text-xs text-red-600 hover:underline" %>
+          
+          <!-- Admin toggle -->
+          <td class="p-2 border">
+            <%= form_with url: toggle_admin_admin_user_path(user), method: :patch, local: true do %>
+              <button type="submit" aria-label="Toggle admin role" class="relative inline-flex items-center h-6 w-11 rounded-full transition-colors focus:outline-none
+                <%= user.admin? ? 'bg-yellow-500' : 'bg-gray-300' %>">
+                <span class="sr-only">Toggle Admin Role</span>
+                <span class="inline-block h-4 w-4 transform bg-white rounded-full transition-transform duration-200 ease-in-out
+                  <%= user.admin? ? 'translate-x-6' : 'translate-x-1' %>">
+                </span>
+              </button>
+            <% end %>
+          </td>
+
+          <!-- Active toggle -->
+          <td class="p-2 border">
+            <%= form_with url: toggle_active_admin_user_path(user), method: :patch, local: true do %>
+              <button type="submit" aria-label="Toggle user active status" class="relative inline-flex items-center h-6 w-11 rounded-full transition-colors focus:outline-none
+                <%= user.active? ? 'bg-green-500' : 'bg-red-500' %>">
+                <span class="sr-only">Toggle Active Status</span>
+                <span class="inline-block h-4 w-4 transform bg-white rounded-full transition-transform duration-200 ease-in-out
+                  <%= user.active? ? 'translate-x-6' : 'translate-x-1' %>">
+                </span>
+              </button>
+            <% end %>
           </td>
         </tr>
       <% end %>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,6 +1,26 @@
 <div class="max-w-5xl mx-auto p-6">
   <h1 class="text-2xl font-bold mb-6">User Management</h1>
 
+  <%= form_with url: admin_users_path, method: :get, local: true, class: "mb-6 flex gap-4 items-end" do %>
+    <div class="flex flex-col">
+      <%= label_tag :role, "Role", class: "text-sm font-medium" %>
+      <%= select_tag :role,
+            options_for_select([["All", ""]] + User.roles.keys.map { |r| [r.titleize, r] }, params[:role]),
+            class: "border rounded p-1" %>
+    </div>
+
+    <div class="flex flex-col">
+      <%= label_tag :active, "Status", class: "text-sm font-medium" %>
+      <%= select_tag :active,
+            options_for_select([["All", ""], ["Active", "true"], ["Inactive", "false"]], params[:active]),
+            class: "border rounded p-1" %>
+    </div>
+
+    <div>
+      <%= submit_tag "Filter", class: "bg-blue-600 text-white px-3 py-1 rounded hover:bg-blue-700" %>
+    </div>
+  <% end %>
+
   <table class="w-full table-auto border-collapse">
     <thead>
       <tr class="bg-gray-100 text-left">
@@ -8,6 +28,7 @@
         <th class="p-2 border">Email</th>
         <th class="p-2 border">Role</th>
         <th class="p-2 border">Created At</th>
+        <th class="p-2 border">Actions</th>
       </tr>
     </thead>
     <tbody>
@@ -17,6 +38,10 @@
           <td class="p-2 border"><%= user.email %></td>
           <td class="p-2 border capitalize"><%= user.role %></td>
           <td class="p-2 border text-sm text-gray-600"><%= user.created_at.strftime("%Y-%m-%d %H:%M") %></td>
+          <td class="p-2 border space-x-2">
+            <%= button_to "Toggle Admin", toggle_admin_admin_user_path(user), method: :patch, class: "text-xs text-blue-600 hover:underline" %>
+            <%= button_to (user.active? ? "Deactivate" : "Reactivate"), toggle_active_admin_user_path(user), method: :patch, class: "text-xs text-red-600 hover:underline" %>
+          </td>
         </tr>
       <% end %>
     </tbody>

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -7,6 +7,10 @@
     <nav class="space-x-4">
       <%= link_to "Adopt", pets_path, class: "text-blue-600 hover:underline" %>
       
+      <% if user_signed_in? && current_user.admin? %>
+        <%= link_to "Admin", admin_dashboard_path, class: "text-sm text-red-600 hover:underline" %>
+      <% end %>
+
       <% if user_signed_in? %>
         <% unread_count = current_user.notifications.unread.count %>
         <%= link_to dashboard_path, class: "relative inline-block" do %>

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -8,7 +8,7 @@ en:
       send_paranoid_instructions: "If your email address exists in our database, you will receive an email with instructions for how to confirm your email address in a few minutes."
     failure:
       already_authenticated: "You are already signed in."
-      inactive: "Your account is not activated yet."
+      inactive: "Your account has been deactivated. Please contact support."
       invalid: "Invalid %{authentication_keys} or password."
       locked: "Your account is locked."
       last_attempt: "You have one more attempt before your account is locked."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,8 +2,9 @@
 
 Rails.application.routes.draw do
   namespace :admin do
+    resources :users, only: [:index]
     get "/", to: "dashboard#index", as: :dashboard
-  end  
+  end
 
   resources :notifications, only: [] do
     member do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
   namespace :admin do
     resources :pets, only: [:index] do
       member do
-        patch :toggle_status
+        patch :toggle_visibility
       end
     end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,13 @@
 
 Rails.application.routes.draw do
   namespace :admin do
-    resources :users, only: [:index]
+    resources :users, only: [:index] do
+      member do
+        patch :toggle_admin
+        patch :toggle_active
+      end
+    end
+
     get "/", to: "dashboard#index", as: :dashboard
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
+  namespace :admin do
+    get "/", to: "dashboard#index", as: :dashboard
+  end  
+
   resources :notifications, only: [] do
     member do
       patch :mark_as_read

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,12 @@
 
 Rails.application.routes.draw do
   namespace :admin do
+    resources :pets, only: [:index] do
+      member do
+        patch :toggle_status
+      end
+    end
+
     resources :users, only: [:index] do
       member do
         patch :toggle_admin

--- a/db/migrate/20250417171954_add_active_to_users.rb
+++ b/db/migrate/20250417171954_add_active_to_users.rb
@@ -1,0 +1,5 @@
+class AddActiveToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :active, :boolean, default: true, null: false
+  end
+end

--- a/db/migrate/20250417173807_add_visible_to_pets.rb
+++ b/db/migrate/20250417173807_add_visible_to_pets.rb
@@ -1,0 +1,5 @@
+class AddVisibleToPets < ActiveRecord::Migration[7.1]
+  def change
+    add_column :pets, :visible, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_04_17_171954) do
+ActiveRecord::Schema[7.1].define(version: 2025_04_17_173807) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -72,6 +72,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_17_171954) do
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "visible", default: true, null: false
     t.index ["user_id"], name: "index_pets_on_user_id"
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_04_17_143935) do
+ActiveRecord::Schema[7.1].define(version: 2025_04_17_171954) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -84,6 +84,7 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_17_143935) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "role", default: 0, null: false
+    t.boolean "active", default: true, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["role"], name: "index_users_on_role"


### PR DESCRIPTION
### 📋 Description

This PR introduces a fully functional admin panel for StrayPawBridge, giving admins tools to monitor and manage platform users and pet listings.

#### 🛠 Admin Panel Structure
- Namespaced controllers and routes under `/admin`
- `Admin::BaseController` with admin-only access protection
- Top navigation link (visible only to admins)

#### 👥 User Management (#19)
- List all users with role and signup date
- Toggle admin role (switch UI)
- Activate/deactivate users (with login restriction)
- Filter users by role and active status

#### 🐾 Pet Listing Moderation (#20)
- List all pet listings with basic details and owner email
- Admin can toggle listing visibility using a modern switch UI
- `visible:boolean` column added to `pets` table

#### 🔒 Login Restrictions
- Inactive users can no longer log in (Devise-based enforcement)
- Custom flash message support for inactive accounts
- 
---

### ✅ Changes Made

- [x] Created/Updated models
- [x] Added/Updated controllers
- [x] Added/Updated views or partials
- [ ] Added/Updated styles
- [ ] Wrote/Updated seeds
- [ ] Added/Updated tests (if applicable)

---

### 📸 Screenshots (Optional)


---

### 🧩 Related Issues

Closes #18, #19, and #20

