### PR TITLE
Feat(i18n): basic internationalization setup with pt-BR default and locale switcher

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,10 +6,20 @@ class ApplicationController < ActionController::Base
   # Optional: handle authorization errors gracefully
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
+  before_action :set_locale
+
   private
 
   def user_not_authorized
     flash[:alert] = "You are not authorized to perform this action."
     redirect_to(request.referer || root_path)
+  end
+
+  def set_locale
+    I18n.locale = params[:locale] || I18n.default_locale
+  end
+
+  def default_url_options
+    { locale: I18n.locale }
   end
 end

--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,12 +1,14 @@
 <header class="bg-white shadow mb-6">
-  <div class="container mx-auto px-4 py-4 flex justify-between items-center">
+  <div class="container mx-auto px-4 py-4 flex items-center justify-between">
+    <!-- Left: Logo -->
     <h1 class="text-xl font-bold">
       <%= link_to "StrayPawBridge", root_path, class: "hover:underline" %>
     </h1>
 
-    <nav class="space-x-4">
+    <!-- Middle: Nav links -->
+    <nav class="space-x-4 flex items-center">
       <%= link_to "Adopt", pets_path, class: "text-blue-600 hover:underline" %>
-      
+
       <% if user_signed_in? && current_user.admin? %>
         <%= link_to "Admin", admin_dashboard_path, class: "text-sm text-red-600 hover:underline" %>
       <% end %>
@@ -23,9 +25,9 @@
           <% end %>
         <% end %>
       <% end %>
-      
+
       <% if user_signed_in? %>
-        <span>Welcome, <%= current_user.email %>!</span>
+        <span class="text-sm">Welcome, <%= current_user.email %>!</span>
         <%= link_to 'Edit Profile', edit_user_registration_path, class: "text-blue-600 hover:underline" %>
         <%= link_to 'Log out', destroy_user_session_path, method: :delete, class: "text-red-600 hover:underline" %>
       <% else %>
@@ -33,5 +35,15 @@
         <%= link_to 'Log in', new_user_session_path, class: "text-blue-600 hover:underline" %>
       <% end %>
     </nav>
+
+    <!-- Right: Language Switcher -->
+    <div>
+      <%= form_with url: request.path, method: :get, local: true do %>
+        <select name="locale" onchange="this.form.submit()" class="p-2 border rounded text-sm">
+          <option value="pt-BR" <%= 'selected' if I18n.locale.to_s == 'pt-BR' %>>🇧🇷 PT</option>
+          <option value="en" <%= 'selected' if I18n.locale == :en %>>🇺🇸 EN</option>
+        </select>
+      <% end %>
+    </div>
   </div>
 </header>

--- a/config/application.rb
+++ b/config/application.rb
@@ -44,5 +44,8 @@ module StrayPawBridge
     # Custom
     config.action_mailer.preview_path = "#{Rails.root}/spec/mailers/previews"
     config.active_job.queue_adapter = :sidekiq
+    config.i18n.available_locales = [:en, :'pt-BR']
+    config.i18n.default_locale = :'pt-BR'
+    config.i18n.fallbacks = [:en]
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,31 +1,5 @@
-# Files in the config/locales directory are used for internationalization and
-# are automatically loaded by Rails. If you want to use locales other than
-# English, add the necessary files in this directory.
-#
-# To use the locales, use `I18n.t`:
-#
-#     I18n.t "hello"
-#
-# In views, this is aliased to just `t`:
-#
-#     <%= t("hello") %>
-#
-# To use a different locale, set it with `I18n.locale`:
-#
-#     I18n.locale = :es
-#
-# This would use the information in config/locales/es.yml.
-#
-# To learn more about the API, please read the Rails Internationalization guide
-# at https://guides.rubyonrails.org/i18n.html.
-#
-# Be aware that YAML interprets the following case-insensitive strings as
-# booleans: `true`, `false`, `on`, `off`, `yes`, `no`. Therefore, these strings
-# must be quoted to be interpreted as strings. For example:
-#
-#     en:
-#       "yes": yup
-#       enabled: "ON"
-
 en:
-  hello: "Hello world"
+  hello: "Hello"
+  devise:
+    sessions:
+      signed_in: "Signed in successfully."

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -1,0 +1,147 @@
+pt-BR:
+  activerecord:
+    attributes:
+      user:
+        confirmation_sent_at: Confirmação enviada em
+        confirmation_token: Token de confirmação
+        confirmed_at: Confirmado em
+        created_at: Criado em
+        current_password: Senha atual
+        current_sign_in_at: Atualmente logado em
+        current_sign_in_ip: IP do acesso atual
+        email: E-mail
+        encrypted_password: Senha criptografada
+        failed_attempts: Tentativas sem sucesso
+        last_sign_in_at: Último acesso em
+        last_sign_in_ip: Último IP de acesso
+        locked_at: Bloqueado em
+        password: Senha
+        password_confirmation: Confirme sua senha
+        remember_created_at: Lembrar criado em
+        remember_me: Lembre-se de mim
+        reset_password_sent_at: Resetar senha enviado em
+        reset_password_token: Resetar token de senha
+        sign_in_count: Contagem de acessos
+        unconfirmed_email: E-mail não confirmado
+        unlock_token: Token de desbloqueio
+        updated_at: Atualizado em
+    models:
+      user:
+        one: Usuário
+        other: Usuários
+  devise:
+    confirmations:
+      confirmed: A sua conta foi confirmada com sucesso.
+      new:
+        resend_confirmation_instructions: Reenviar instruções de confirmação
+      send_instructions: Dentro de minutos, você receberá um email com as instruções de confirmação da sua conta.
+      send_paranoid_instructions: Se o seu e-mail existir em nosso banco de dados, você receberá um email com instruções sobre como confirmar sua conta em alguns minutos.
+    failure:
+      already_authenticated: Você já está autenticado.
+      inactive: A sua conta ainda não foi ativada.
+      invalid: "%{authentication_keys} ou senha inválidos."
+      last_attempt: Você tem mais uma única tentativa antes de sua conta ser bloqueada.
+      locked: A sua conta está bloqueada.
+      not_found_in_database: "%{authentication_keys} ou senha inválidos."
+      timeout: A sua sessão expirou, por favor, faça login novamente para continuar.
+      unauthenticated: Para continuar, faça login ou registre-se.
+      unconfirmed: Antes de continuar, confirme a sua conta.
+    mailer:
+      confirmation_instructions:
+        action: Confirmar minha conta
+        greeting: Bem-vindo %{recipient}!
+        instruction: 'Você pode confirmar sua conta através do link abaixo:'
+        subject: Instruções de confirmação
+      email_changed:
+        greeting: Olá %{recipient}!
+        message: Estamos entrando em contato para notificá-lo de que seu e-mail está sendo alterado para %{email}.
+        message_unconfirmed: Estamos entrando em contato para notificá-lo de que seu e-mail está sendo alterado para %{email}.
+        subject: E-mail alterado
+      password_change:
+        greeting: Olá %{recipient}!
+        message: Estamos entrando em contato para notificá-lo de que sua senha foi alterada.
+        subject: Senha alterada
+      reset_password_instructions:
+        action: Redefinir minha senha
+        greeting: Olá %{recipient}!
+        instruction: Alguém fez o pedido para redefinir sua senha, e você pode fazer isso clicando no link abaixo.
+        instruction_2: Se você não fez este pedido, por favor ignore este e-mail.
+        instruction_3: Sua senha não será alterada até que você acesse o link acima e crie uma nova.
+        subject: Instruções de redefinição de senha
+      unlock_instructions:
+        action: Desbloquear minha conta
+        greeting: Olá %{recipient}!
+        instruction: 'Clique no link abaixo para desbloquear sua conta:'
+        message: Sua conta foi bloqueada devido ao excessivo número de tentativas acesso inválidas.
+        subject: Instruções de desbloqueio
+    omniauth_callbacks:
+      failure: Não foi possível autorizar de uma conta de %{kind} porque "%{reason}".
+      success: Autorizado com sucesso de uma conta de %{kind}.
+    passwords:
+      edit:
+        change_my_password: Alterar minha senha
+        change_your_password: Alterar sua senha
+        confirm_new_password: Confirme sua nova senha
+        new_password: Nova senha
+      new:
+        forgot_your_password: Esqueceu sua senha?
+        send_me_reset_password_instructions: Enviar instruções para redefinição da senha
+      no_token: Você não pode acessar esta página sem estar logado. Se você veio de um email de redefinição de senha, por favor certifique-se de ter digitado a URL corretamente.
+      send_instructions: Dentro de minutos, você receberá um e-mail com as instruções de redefinição da sua senha.
+      send_paranoid_instructions: Se o seu email existir em nosso banco de dados, você receberá um email com um link para recuperação da senha.
+      updated: A sua senha foi alterada com sucesso. Você está autenticado.
+      updated_not_active: Sua senha foi alterada com sucesso.
+    registrations:
+      destroyed: Adeus! A sua conta foi cancelada com sucesso. Esperamos vê-lo novamente em breve.
+      edit:
+        are_you_sure: Você tem certeza?
+        cancel_my_account: Cancelar minha conta
+        currently_waiting_confirmation_for_email: 'No momento esperando por: %{email}'
+        leave_blank_if_you_don_t_want_to_change_it: deixe em branco caso não queira alterá-la
+        title: Editar %{resource}
+        unhappy: Não está contente?
+        update: Atualizar
+        we_need_your_current_password_to_confirm_your_changes: precisamos da sua senha atual para confirmar suas mudanças
+      new:
+        sign_up: Inscrever-se
+      signed_up: Bem vindo! Você realizou seu registro com sucesso.
+      signed_up_but_inactive: Você se inscreveu com sucesso, porém nós não podemos autenticá-lo porque sua conta ainda não foi ativada.
+      signed_up_but_locked: Você se inscreveu com sucesso. Porém nós não podemos autenticá-lo porque sua conta está bloqueada.
+      signed_up_but_unconfirmed: Uma mensagem com um link de confirmação foi enviada para o seu e-mail. Por favor, acesse o link para ativar sua conta.
+      update_needs_confirmation: Sua conta foi atualizada com sucesso, mas nós precisamos verificar o novo endereço de email. Por favor, verifique seu e-mail e clique no link de confirmação para finalizar confirmando o seu novo e-mail.
+      updated: A sua conta foi atualizada com sucesso.
+      updated_but_not_signed_in: Sua conta foi atualizada com sucesso, uma vez que sua senha foi alterada será necessário realizar o login novamente.
+    sessions:
+      already_signed_out: Logout efetuado com sucesso.
+      new:
+        sign_in: Login
+      signed_in: Login efetuado com sucesso.
+      signed_out: Logout efetuado com sucesso.
+    shared:
+      links:
+        back: Voltar
+        didn_t_receive_confirmation_instructions: Não recebeu instruções de confirmação?
+        didn_t_receive_unlock_instructions: Não recebeu instruções de desbloqueio?
+        forgot_your_password: Esqueceu sua senha?
+        sign_in: Login
+        sign_in_with_provider: Entrar com %{provider}
+        sign_up: Inscrever-se
+      minimum_password_length:
+        one: "(Mínimo de %{count} caractere)"
+        other: "(Mínimo de %{count} caracteres)"
+    unlocks:
+      new:
+        resend_unlock_instructions: Reenviar instruções de desbloqueio
+      send_instructions: Dentro de minutos, você receberá um e-mail com instruções de desbloqueio da sua conta.
+      send_paranoid_instructions: Se sua conta existir em nosso banco de dados, você receberá em breve um e-mail com instruções para desbloquear ela.
+      unlocked: A sua conta foi desbloqueada com sucesso. Efetue login para continuar.
+  errors:
+    messages:
+      already_confirmed: já foi confirmado
+      confirmation_period_expired: É necessário ser confirmado dentro do período %{period}, por favor requisite um novo usuário.
+      expired: expirou, por favor solicite uma nova
+      not_found: não encontrado
+      not_locked: não foi bloqueado
+      not_saved:
+        one: 'Não foi possível salvar %{resource}: 1 erro'
+        other: 'Não foi possível salvar %{resource}: %{count} erros.'


### PR DESCRIPTION
This PR introduces basic I18n support to prepare StrayPawBridge for multilingual capabilities.

### 🌍 I18n Setup
- Added `pt-BR` as default locale with fallback to `en`
- Locale files created at `config/locales/pt-BR.yml` and `en.yml`
- Set `I18n.locale` from query param (`?locale=pt-BR`) via `ApplicationController`
- `default_url_options` includes locale to persist across routes

### 🌐 Language Switcher
- Added a dropdown in the navbar for users to switch between Portuguese and English
- Locale-aware navigation with safe guards for guest users

### 🛠 Ready for Phase 2:
- View strings, mailers, and UI texts can now be easily translated
- More locales can be added when needed

This sets the foundation for full localization in a future release

---

### ✅ Changes Made

- [ ] Created/Updated models
- [ ] Added/Updated controllers
- [ ] Added/Updated views or partials
- [ ] Added/Updated styles
- [ ] Wrote/Updated seeds
- [ ] Added/Updated tests (if applicable)

---

### 📸 Screenshots (Optional)


---

### 🧩 Related Issues



