### PR TITLE
Add Geolocation Support and Map Display to Pet Listings

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,4 +72,4 @@ gem 'rails-i18n'
 gem 'pry-rails'
 gem "cloudinary"
 gem "activestorage-cloudinary-service"
-
+gem 'geocoder'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,6 +102,7 @@ GEM
     crass (1.0.6)
     cssbundling-rails (1.4.3)
       railties (>= 6.0.0)
+    csv (3.3.3)
     date (3.4.1)
     debug (1.10.0)
       irb (~> 1.10)
@@ -130,6 +131,9 @@ GEM
     faraday-net_http (3.4.0)
       net-http (>= 0.5.0)
     ffi (1.17.1-x86_64-linux-gnu)
+    geocoder (1.8.3)
+      base64 (>= 0.1.0)
+      csv (>= 3.0.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
     hotwire-rails (0.1.3)
@@ -355,6 +359,7 @@ DEPENDENCIES
   debug
   devise
   dotenv-rails
+  geocoder
   hotwire-rails
   image_processing (~> 1.2)
   jsbundling-rails

--- a/app/controllers/pets_controller.rb
+++ b/app/controllers/pets_controller.rb
@@ -10,6 +10,11 @@ class PetsController < ApplicationController
 
     @pets = @pets.where(species: params[:species]) if params[:species].present?
     @pets = @pets.where(size: params[:size]) if params[:size].present?
+
+    if params[:location].present?
+      radius = params[:radius].presence || 20
+      @pets = @pets.near(params[:location], radius, units: :km)
+    end
   end
 
   def show
@@ -65,6 +70,6 @@ class PetsController < ApplicationController
   end
 
   def pet_params
-    params.require(:pet).permit(:name, :description, :species, :age, :size, :status, :photo)
+    params.require(:pet).permit(:name, :description, :species, :age, :size, :status, :photo, :address)
   end
 end

--- a/app/models/pet.rb
+++ b/app/models/pet.rb
@@ -10,4 +10,7 @@ class Pet < ApplicationRecord
   validates :name, :species, :size, :status, presence: true
 
   has_many :adoption_requests, dependent: :destroy
+
+  geocoded_by :address
+  after_validation :geocode, if: :will_save_change_to_address?
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -7,6 +7,8 @@
     <%= csp_meta_tag %>
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
+    <%= stylesheet_link_tag "https://unpkg.com/leaflet@1.9.4/dist/leaflet.css", crossorigin: "" %>
+    <%= javascript_include_tag "https://unpkg.com/leaflet@1.9.4/dist/leaflet.js", crossorigin: "" %>
   </head>
 
   <body class="bg-gray-50 min-h-screen text-gray-900">

--- a/app/views/pets/_filters.html.erb
+++ b/app/views/pets/_filters.html.erb
@@ -15,11 +15,15 @@
     </div>
 
     <div class="flex flex-col">
-      <%= label_tag :location, "Location", class: "text-sm font-medium text-gray-700" %>
-      <%= text_field_tag :location, "", placeholder: "Coming soon...", disabled: true,
-                         class: "p-2 border rounded-md bg-gray-100 text-gray-400" %>
+      <%= label_tag :location, "Near Location", class: "text-sm font-medium text-gray-700" %>
+      <%= text_field_tag :location, params[:location], placeholder: "e.g. São Paulo, Brazil", class: "p-2 border rounded-md" %>
     </div>
 
+    <div class="flex flex-col">
+      <%= label_tag :radius, "Radius (km)", class: "text-sm font-medium text-gray-700" %>
+      <%= number_field_tag :radius, params[:radius] || 20, class: "p-2 border rounded-md", min: 1 %>
+    </div>
+    
     <div>
       <%= submit_tag "Filter", class: "bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700" %>
     </div>

--- a/app/views/pets/_pet_details.html.erb
+++ b/app/views/pets/_pet_details.html.erb
@@ -9,7 +9,28 @@
   <p><strong>Species:</strong> <%= pet.species.titleize %></p>
   <p><strong>Size:</strong> <%= pet.size %></p>
   <p><strong>Status:</strong> <%= pet.status.titleize %></p>
+  
   <% if pet.age.present? %>
     <p><strong>Age:</strong> <%= pet.age %> years</p>
+  <% end %>
+
+  <% if @pet.latitude.present? && @pet.longitude.present? %>
+    <div class="mt-6">
+      <h3 class="text-md font-semibold mb-2">Location</h3>
+      <div id="map" class="w-full h-64 rounded-md shadow"></div>
+
+      <script>
+        document.addEventListener("DOMContentLoaded", function () {
+          const map = L.map('map').setView([<%= @pet.latitude %>, <%= @pet.longitude %>], 13);
+
+          L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+            attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+          }).addTo(map);
+
+          L.marker([<%= @pet.latitude %>, <%= @pet.longitude %>]).addTo(map)
+            .bindPopup('<strong><%= j @pet.name %></strong><br><%= j @pet.address %>');
+        });
+      </script>
+    </div>
   <% end %>
 </div>

--- a/app/views/pets/edit.html.erb
+++ b/app/views/pets/edit.html.erb
@@ -38,6 +38,11 @@
   </div>
 
   <div class="flex flex-col">
+    <%= f.label :address, class: "text-sm font-medium" %>
+    <%= f.text_field :address, class: "p-2 border rounded-md" %>
+  </div>
+
+  <div class="flex flex-col">
     <%= f.label :photo, class: "text-sm font-medium text-gray-700" %>
     <%= f.file_field :photo, class: "p-2 border rounded-md" %>
   </div>

--- a/app/views/pets/new.html.erb
+++ b/app/views/pets/new.html.erb
@@ -38,6 +38,11 @@
   </div>
 
   <div class="flex flex-col">
+    <%= f.label :address, class: "text-sm font-medium" %>
+    <%= f.text_field :address, class: "p-2 border rounded-md" %>
+  </div>
+
+  <div class="flex flex-col">
     <%= f.label :photo, class: "text-sm font-medium text-gray-700" %>
     <%= f.file_field :photo, class: "p-2 border rounded-md" %>
   </div>

--- a/db/migrate/20250420235635_add_address_to_pets.rb
+++ b/db/migrate/20250420235635_add_address_to_pets.rb
@@ -1,0 +1,7 @@
+class AddAddressToPets < ActiveRecord::Migration[7.1]
+  def change
+    add_column :pets, :address, :string
+    add_column :pets, :latitude, :float
+    add_column :pets, :longitude, :float
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_04_17_173807) do
+ActiveRecord::Schema[7.1].define(version: 2025_04_20_235635) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -73,6 +73,9 @@ ActiveRecord::Schema[7.1].define(version: 2025_04_17_173807) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "visible", default: true, null: false
+    t.string "address"
+    t.float "latitude"
+    t.float "longitude"
     t.index ["user_id"], name: "index_pets_on_user_id"
   end
 


### PR DESCRIPTION
### 📋 Description

This PR introduces geolocation features to improve how users browse and interact with pet listings:
    - Address & Geocoding
    - Added address, latitude, and longitude fields to the pets table
    - Integrated the [Geocoder](https://github.com/alexreisner/geocoder) gem to automatically geocode addresses
    - Updated the pet creation/edit forms to include a single address input
    - Address is now used to compute coordinates on save

🗺️ Map Visualization
    - Embedded a Leaflet.js map on the pet’s detail page to show the rescue location
    - Automatically centers and pins the location based on coordinates

🔎 Filtering by Location
    - Users can filter pet listings by typing a location and selecting a search radius
    - Implemented location-based filtering in the PetsController#index using near from Geocoder
    - Updated the filter form to support location and radius parameters

---

### ✅ Changes Made

- [ ] Created/Updated models
- [ ] Added/Updated controllers
- [ ] Added/Updated views or partials
- [ ] Added/Updated styles
- [ ] Wrote/Updated seeds
- [ ] Added/Updated tests (if applicable)

---

### 📸 Screenshots (Optional)


---

### 🧩 Related Issues



